### PR TITLE
Add more Dataset metadata

### DIFF
--- a/docs/dspl2-spec.md
+++ b/docs/dspl2-spec.md
@@ -124,6 +124,21 @@ A dataset that contains statistical data. It has the following properties
   "name": "Unemployment in Europe (monthly)",
   "description": "Harmonized unemployment data for European countries.",
   "url": "http://epp.eurostat.ec.europa.eu/portal/page/portal/lang-en/employment_unemployment_lfs/introduction",
+  "license": "https://ec.europa.eu/eurostat/about/policies/copyright",
+  "creator":{
+     "@type":"Organization",
+     "url": "https://ec.europa.eu/eurostat",
+     "name":"Eurostat",
+  },
+  "temporalCoverage":"1993-01/2010-12",
+  "spatialCoverage":{
+     "@type":"Place",
+     "geo":{
+       "@type":"GeoShape",
+       "name": "European Union",
+        "box":"34.633285 -10.468556 70.096054 34.597916"
+     }
+  },
   "measure": …,
   "dimension": …,
   "footnote": …,
@@ -823,6 +838,21 @@ Below, all the dimensions, measures, footnotes and slices are defined in CSV fil
   "name": "Unemployment in Europe (monthly)",
   "description": "Harmonized unemployment data for European countries.",
   "url": "http://epp.eurostat.ec.europa.eu/portal/page/portal/lang-en/employment_unemployment_lfs/introduction",
+  "license": "https://ec.europa.eu/eurostat/about/policies/copyright",
+  "creator":{
+     "@type":"Organization",
+     "url": "https://ec.europa.eu/eurostat",
+     "name":"Eurostat",
+  },
+  "temporalCoverage":"1993-01/2010-12",
+  "spatialCoverage":{
+     "@type":"Place",
+     "geo":{
+       "@type":"GeoShape",
+       "name": "European Union",
+        "box":"34.633285 -10.468556 70.096054 34.597916"
+     }
+  },
   "measure": [
     {
       "@type": "StatisticalMeasure",
@@ -895,6 +925,21 @@ Below, data for all properties is provided inline as JSON:
   "name": "Le Ch\u00f4mage en Europe (mensuel)",
   "description": "Harmonized unemployment data for European countries. This dataset was prepared by Google based on data downloaded from Eurostat.",
   "url": "http://epp.eurostat.ec.europa.eu/portal/page/portal/lang-en/employment_unemployment_lfs/introduction",
+  "license": "https://ec.europa.eu/eurostat/about/policies/copyright",
+  "creator":{
+     "@type":"Organization",
+     "url": "https://ec.europa.eu/eurostat",
+     "name":"Eurostat",
+  },
+  "temporalCoverage":"1993-01/2010-12",
+  "spatialCoverage":{
+     "@type":"Place",
+     "geo":{
+       "@type":"GeoShape",
+       "name": "European Union",
+        "box":"34.633285 -10.468556 70.096054 34.597916"
+     }
+  },
   "dimension": [
     {
       "@id": "#country",

--- a/samples/eurostat/unemployment/eurostat-unemployment-dspl-v1-inline-small.json
+++ b/samples/eurostat/unemployment/eurostat-unemployment-dspl-v1-inline-small.json
@@ -16,6 +16,7 @@
       "@value": "Donn\u00e9es harmonis\u00e9es sur le ch\u00f4mage dans les pays europ\u00e9ens. Ces donn\u00e9es ont \u00e9t\u00e9 pr\u00e9par\u00e9es par Google sur la base de donn\u00e9es t\u00e9l\u00e9charg\u00e9es \u00e0 partir d'Eurostat."
     }
   ],
+  "license": "https://ec.europa.eu/eurostat/about/policies/copyright",
   "creator":{
      "@type":"Organization",
      "url": "https://ec.europa.eu/eurostat",

--- a/samples/eurostat/unemployment/eurostat-unemployment-dspl-v1.json
+++ b/samples/eurostat/unemployment/eurostat-unemployment-dspl-v1.json
@@ -24,6 +24,7 @@
     "de": "http://epp.eurostat.ec.europa.eu/portal/page/portal/lang-fr/employment_unemployment_lfs/introduction",
     "fr": "http://epp.eurostat.ec.europa.eu/portal/page/portal/lang-de/employment_unemployment_lfs/introduction"
   },
+  "license": "https://ec.europa.eu/eurostat/about/policies/copyright",
   "creator":{
      "@type":"Organization",
      "url": "https://ec.europa.eu/eurostat",


### PR DESCRIPTION
This adds

* `license` to the JSON-LD examples
* Dataset metadata to the examples in the DSPL 2 spec.