### PR TITLE
Fix Chilean Currencies

### DIFF
--- a/samples/google/canonical/currencies.csv
+++ b/samples/google/canonical/currencies.csv
@@ -26,7 +26,8 @@ BZD,"Belize Dollar",BZ$
 CAD,"Canadian Dollar",$
 CDF,"Congolese Franc",
 CHF,"Swiss Franc",CHF
-"CLP CLF","Chilean Peso Unidades de fomento",$
+CLP,"Chilean Peso",$
+CLF,"Chilean Unidades de fomento",UF
 CNY,"Yuan Renminbi",¥
 "COP COU","Colombian Peso Unidad de Valor Real",$
 CRC,"Costa Rican Colon",₡


### PR DESCRIPTION
There are two Chilean Currencies, one is CLF also know UF, mostly used for real states, it is a currency with inflation included. The other currency is CLP, Chilean Peso. the currency used daily by Chilean people.